### PR TITLE
Add support for alternative status messages

### DIFF
--- a/include/trial/http/curl/detail/socket.ipp
+++ b/include/trial/http/curl/detail/socket.ipp
@@ -145,6 +145,7 @@ inline socket::socket(boost::asio::io_service& io)
     current.state = state::done;
     current.message = 0;
     current.header = 0;
+    http_200_aliases = 0;
 
     easy = ::curl_easy_init();
     if (!easy)
@@ -185,9 +186,23 @@ inline socket::~socket()
 
     ::curl_slist_free_all(current.header);
     current.header = 0;
+    ::curl_slist_free_all(http_200_aliases);
+    http_200_aliases = 0;
     ::curl_multi_remove_handle(multi, easy);
     ::curl_multi_cleanup(multi);
     ::curl_easy_cleanup(easy);
+}
+
+inline void socket::add_http_200_aliases(const std::list<std::string>& http200AliasList)
+{
+    if (!http200AliasList.empty())
+    {
+        for (std::list<std::string>::const_iterator it = http200AliasList.begin(); it != http200AliasList.end(); ++it)
+        {
+            http_200_aliases = curl_slist_append(http_200_aliases, (*it).c_str());
+        }
+        ::curl_easy_setopt(easy, CURLOPT_HTTP200ALIASES, http_200_aliases);
+    }
 }
 
 template <typename CompletionToken>

--- a/include/trial/http/curl/socket.hpp
+++ b/include/trial/http/curl/socket.hpp
@@ -14,6 +14,7 @@
 #include <curl/curl.h>
 #include <string>
 #include <map>
+#include <list>
 #include <boost/system/error_code.hpp>
 #include <boost/asio/basic_io_object.hpp>
 #include <boost/asio/socket_base.hpp>
@@ -112,6 +113,8 @@ public:
 
     bool is_open() const;
 
+    inline void add_http_200_aliases(const std::list<std::string>& http200AliasList);
+
 private:
     static curl_socket_t curl_open_callback(void *, curlsocktype, struct curl_sockaddr *);
     static int curl_close_callback(void *, curl_socket_t);
@@ -159,6 +162,7 @@ private:
     CURL *easy;
     CURLM *multi;
     boost::asio::basic_waitable_timer<boost::chrono::steady_clock> timer;
+    struct curl_slist *http_200_aliases;
 
     struct state
     {


### PR DESCRIPTION
This change allows the caller to define alternative status messages
that should be accepted as well as `HTTP 200 OK`, such as
`ICY 200 OK`.